### PR TITLE
Fixed overflowing content in a card from blog.

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -52,4 +52,16 @@ ul li a:link{
 
 .card-title{
   color: black;
+  padding: 0 !important;
+}
+
+/* Completed Courses section - To fix overflowing card title and content from Completed Courses card when it is active */
+.card,
+.card-title {
+  position: relative !important;
+}
+
+/* Removes unnecessary margin at the bottom of Completed Courses card when it is active */
+.row .collapsible .active .collapsible-body span .row {
+  margin-bottom: 0 !important;
 }


### PR DESCRIPTION
Fixes issue #119 
Fixed card-title padding and content overflow.
Fixed unnecessary margin below the card.